### PR TITLE
feat(composed screen reader messages): aria-hide element callouts in favor of composed messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ For the most up to date information on [UI development browser support](https://
 [![Build Status](https://img.shields.io/github/workflow/status/AlaskaAirlines/auro-flight/Test%20and%20publish?branch=master&style=for-the-badge)](https://github.com/AlaskaAirlines/auro-flight/actions?query=workflow%3A%22test+and+publish%22)
 [![See it on NPM!](https://img.shields.io/npm/v/@aurodesignsystem/auro-flight?style=for-the-badge&color=orange)](https://www.npmjs.com/package/@aurodesignsystem/auro-flight)
 [![License](https://img.shields.io/npm/l/@aurodesignsystem/auro-flight?color=blue&style=for-the-badge)](https://www.apache.org/licenses/LICENSE-2.0)
+[![Snyk Vulnerabilities for npm package](https://img.shields.io/snyk/vulnerabilities/npm/@aurodesignsystem/auro-flight?style=for-the-badge)](https://snyk.io/test/npm/@aurodesignsystem/auro-flight?tab=issues)
 
 ```shell
 $ npm i @aurodesignsystem/auro-flight

--- a/apiExamples/changeofgauge.html
+++ b/apiExamples/changeofgauge.html
@@ -4,7 +4,8 @@
   departureTime="2022-04-13T01:10:00-07:00"
   departureStation="SEA"
   arrivalTime="2022-04-13T12:30:00-04:00"
-  arrivalStation="EWR">
+  arrivalStation="EWR"
+  stops='[{ "isStopover": true, "arrivalStation": "LAX"}]'>
   <auro-flightline>
     <auro-flight-segment iata="LAX">
   </auro-flightline>

--- a/apiExamples/connection.html
+++ b/apiExamples/connection.html
@@ -4,14 +4,15 @@
   departureTime="2022-07-21T00:55:00-09:00"
   departureStation="ANC"
   arrivalTime="2022-07-21T16:39:00-04:00"
-  arrivalStation="BOS">
+  arrivalStation="BOS"
+  stops='[{ "isStopover": false, "arrivalStation": "ORD", "duration":"3h 10m" }]'>
   <auro-flightline>
     <auro-flight-segment iata="ORD" duration="3h 10m"></auro-flight-segment>
   </auro-flightline>
   <span slot="footer">
-    <auro-icon category="logos" name="tail-AS" style="width: 24px"></auro-icon>
-    AS161 is subject to government approval <br />
-    <auro-icon category="logos" name="tail-AA" style="width: 24px"></auro-icon>
+    <auro-icon category="logos" name="tail-AS" style="width: 24px" aria-hidden="true"></auro-icon>
+    AS161 is subject to government approval <br aria-hidden="true"/>
+    <auro-icon category="logos" name="tail-AA" style="width: 24px" aria-hidden="true"></auro-icon>
     AA2269 is operated by American Airlines
   </span>
 </auro-flight>

--- a/apiExamples/footerSlot.html
+++ b/apiExamples/footerSlot.html
@@ -7,9 +7,9 @@
   arrivalStation="CPT">
   <auro-flightline></auro-flightline>
   <span slot="footer">
-    <auro-icon category="logos" name="tail-EK" style="width: 24px"></auro-icon>
-    EK 772 is subject to government approval <br />
-    <auro-icon category="logos" name="tail-EK" style="width: 24px"></auro-icon>
+    <auro-icon category="logos" name="tail-EK" style="width: 24px" aria-hidden="true"></auro-icon>
+    EK 772 is subject to government approval <br  aria-hidden="true"/>
+    <auro-icon category="logos" name="tail-EK" style="width: 24px" aria-hidden="true"></auro-icon>
     EK 772 is operated by Emirates
   </span>
 </auro-flight>

--- a/apiExamples/multiStop.html
+++ b/apiExamples/multiStop.html
@@ -4,7 +4,10 @@
   departureTime="2022-05-04T00:00:00-09:00"
   departureStation="KTN"
   arrivalTime="2022-05-04T05:53:00-09:00"
-  arrivalStation="ANC">
+  arrivalStation="ANC"    
+  stops='[{ "isStopover": true, "arrivalStation": "WRG"}, 
+    { "isStopover": true, "arrivalStation": "PSG"}, 
+    { "isStopover": true, "arrivalStation": "JNU"}]'>
   <auro-flightline>
     <auro-flight-segment stopover iata="WRG"></auro-flight-segment>
     <auro-flight-segment stopover iata="PSG"></auro-flight-segment>

--- a/apiExamples/oneStop.html
+++ b/apiExamples/oneStop.html
@@ -4,7 +4,8 @@
   departureTime="2022-05-04T01:55:00-09:00"
   departureStation="ANC"
   arrivalTime="2022-05-04T03:55:00-09:00"
-  arrivalStation="ADK">
+  arrivalStation="ADK"
+  stops='[{ "isStopover": true, "arrivalStation": "CDB"}]'>
   <auro-flightline>
     <auro-flight-segment stopover iata="CDB"></auro-flight-segment>
   </auro-flightline>

--- a/demo/demo.md
+++ b/demo/demo.md
@@ -116,7 +116,8 @@ This example illustrates a one-stop `stopover` flight from ANC to ADK. Notice th
     departureTime="2022-05-04T01:55:00-09:00"
     departureStation="ANC"
     arrivalTime="2022-05-04T03:55:00-09:00"
-    arrivalStation="ADK">
+    arrivalStation="ADK"
+    stops='[{ "isStopover": true, "arrivalStation": "CDB"}]'>
     <auro-flightline>
       <auro-flight-segment stopover iata="CDB"></auro-flight-segment>
     </auro-flightline>
@@ -135,7 +136,8 @@ This example illustrates a one-stop `stopover` flight from ANC to ADK. Notice th
   departureTime="2022-05-04T01:55:00-09:00"
   departureStation="ANC"
   arrivalTime="2022-05-04T03:55:00-09:00"
-  arrivalStation="ADK">
+  arrivalStation="ADK"
+  stops='[{ "isStopover": true, "arrivalStation": "CDB"}]'>
   <auro-flightline>
     <auro-flight-segment stopover iata="CDB"></auro-flight-segment>
   </auro-flightline>
@@ -157,7 +159,10 @@ The following example illustrates a mainline multi-stop `stopover` flight from K
     departureTime="2022-05-04T00:00:00-09:00"
     departureStation="KTN"
     arrivalTime="2022-05-04T05:53:00-09:00"
-    arrivalStation="ANC">
+    arrivalStation="ANC"    
+    stops='[{ "isStopover": true, "arrivalStation": "WRG"}, 
+      { "isStopover": true, "arrivalStation": "PSG"}, 
+      { "isStopover": true, "arrivalStation": "JNU"}]'>
     <auro-flightline>
       <auro-flight-segment stopover iata="WRG"></auro-flight-segment>
       <auro-flight-segment stopover iata="PSG"></auro-flight-segment>
@@ -178,7 +183,10 @@ The following example illustrates a mainline multi-stop `stopover` flight from K
   departureTime="2022-05-04T00:00:00-09:00"
   departureStation="KTN"
   arrivalTime="2022-05-04T05:53:00-09:00"
-  arrivalStation="ANC">
+  arrivalStation="ANC"    
+  stops='[{ "isStopover": true, "arrivalStation": "WRG"}, 
+    { "isStopover": true, "arrivalStation": "PSG"}, 
+    { "isStopover": true, "arrivalStation": "JNU"}]'>
   <auro-flightline>
     <auro-flight-segment stopover iata="WRG"></auro-flight-segment>
     <auro-flight-segment stopover iata="PSG"></auro-flight-segment>
@@ -202,14 +210,15 @@ The following example illustrates a change of gauge flight with a layover in SEA
     departureTime="2022-07-21T00:55:00-09:00"
     departureStation="ANC"
     arrivalTime="2022-07-21T16:39:00-04:00"
-    arrivalStation="BOS">
+    arrivalStation="BOS"
+    stops='[{ "isStopover": false, "arrivalStation": "ORD", "duration":"3h 10m" }]'>
     <auro-flightline>
       <auro-flight-segment iata="ORD" duration="3h 10m"></auro-flight-segment>
     </auro-flightline>
     <span slot="footer">
-      <auro-icon category="logos" name="tail-AS" style="width: 24px"></auro-icon>
-      AS161 is subject to government approval <br />
-      <auro-icon category="logos" name="tail-AA" style="width: 24px"></auro-icon>
+      <auro-icon category="logos" name="tail-AS" style="width: 24px" aria-hidden="true"></auro-icon>
+      AS161 is subject to government approval <br aria-hidden="true"/>
+      <auro-icon category="logos" name="tail-AA" style="width: 24px" aria-hidden="true"></auro-icon>
       AA2269 is operated by American Airlines
     </span>
   </auro-flight>
@@ -227,14 +236,15 @@ The following example illustrates a change of gauge flight with a layover in SEA
   departureTime="2022-07-21T00:55:00-09:00"
   departureStation="ANC"
   arrivalTime="2022-07-21T16:39:00-04:00"
-  arrivalStation="BOS">
+  arrivalStation="BOS"
+  stops='[{ "isStopover": false, "arrivalStation": "ORD", "duration":"3h 10m" }]'>
   <auro-flightline>
     <auro-flight-segment iata="ORD" duration="3h 10m"></auro-flight-segment>
   </auro-flightline>
   <span slot="footer">
-    <auro-icon category="logos" name="tail-AS" style="width: 24px"></auro-icon>
-    AS161 is subject to government approval <br />
-    <auro-icon category="logos" name="tail-AA" style="width: 24px"></auro-icon>
+    <auro-icon category="logos" name="tail-AS" style="width: 24px" aria-hidden="true"></auro-icon>
+    AS161 is subject to government approval <br aria-hidden="true"/>
+    <auro-icon category="logos" name="tail-AA" style="width: 24px" aria-hidden="true"></auro-icon>
     AA2269 is operated by American Airlines
   </span>
 </auro-flight>
@@ -244,7 +254,9 @@ The following example illustrates a change of gauge flight with a layover in SEA
 
 ## Using the footer slot
 
-In this example for a flight that requires government approval or a flight that is operated by another subsidiary or partner carrier, you can use the `footer` custom element slot to insert additional information into the scope of the component. In the code you will see the use of `<auro-icon>` and text within the named slot element.
+In this example for a flight that requires government approval or a flight that is operated by another subsidiary or partner carrier, you can use the `footer` custom element slot to insert additional information into the scope of the component. Notice the use of `<auro-icon>` and text within the named slot element.
+
+This slot requires the consumer to manually manage what is read back via the screen reader through the use of `aria-hidden="true"`.
 
 <div class="exampleWrapper">
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../../apiExamples/footerSlot.html) -->
@@ -258,9 +270,9 @@ In this example for a flight that requires government approval or a flight that 
     arrivalStation="CPT">
     <auro-flightline></auro-flightline>
     <span slot="footer">
-      <auro-icon category="logos" name="tail-EK" style="width: 24px"></auro-icon>
-      EK 772 is subject to government approval <br />
-      <auro-icon category="logos" name="tail-EK" style="width: 24px"></auro-icon>
+      <auro-icon category="logos" name="tail-EK" style="width: 24px" aria-hidden="true"></auro-icon>
+      EK 772 is subject to government approval <br  aria-hidden="true"/>
+      <auro-icon category="logos" name="tail-EK" style="width: 24px" aria-hidden="true"></auro-icon>
       EK 772 is operated by Emirates
     </span>
   </auro-flight>
@@ -281,9 +293,9 @@ In this example for a flight that requires government approval or a flight that 
   arrivalStation="CPT">
   <auro-flightline></auro-flightline>
   <span slot="footer">
-    <auro-icon category="logos" name="tail-EK" style="width: 24px"></auro-icon>
-    EK 772 is subject to government approval <br />
-    <auro-icon category="logos" name="tail-EK" style="width: 24px"></auro-icon>
+    <auro-icon category="logos" name="tail-EK" style="width: 24px" aria-hidden="true"></auro-icon>
+    EK 772 is subject to government approval <br  aria-hidden="true"/>
+    <auro-icon category="logos" name="tail-EK" style="width: 24px" aria-hidden="true"></auro-icon>
     EK 772 is operated by Emirates
   </span>
 </auro-flight>
@@ -381,7 +393,7 @@ Department of Transportation regulations mandate that the arrival and departure 
 
 ## Accessibility
 
-The `<auro-flight>` custom element is accessible by screen readers by default. Due to the style of content within, while this is accessible, it's up to the user of the element if this information is useable and/or necessary for a screen reader experience. If this element is being used for illustrative purposes and the details of the flight are outlined in greater detail outside the scope of this element, it is recommended that the `ariaHidden` attribute be used.
+The `<auro-flight>` custom element is accessible by screen readers by default. Due to the style of content within, while this is accessible, it's up to the user of the element to determine if information is useable and/or necessary for a screen reader experience. If this element is being used for illustrative purposes and the details of the flight are outlined in greater detail outside the scope of this element, `aria-hidden='true'` is recommended.
 
 ## SEO
 

--- a/demo/dotCompliance.md
+++ b/demo/dotCompliance.md
@@ -18,7 +18,8 @@ See [documentation](https://auro.alaskaair.com/components/auro/flightline/api) f
     departureTime="2022-04-13T01:10:00-07:00"
     departureStation="SEA"
     arrivalTime="2022-04-13T12:30:00-04:00"
-    arrivalStation="EWR">
+    arrivalStation="EWR"
+    stops='[{ "isStopover": true, "arrivalStation": "LAX"}]'>
     <auro-flightline>
       <auro-flight-segment iata="LAX">
     </auro-flightline>
@@ -37,7 +38,8 @@ See [documentation](https://auro.alaskaair.com/components/auro/flightline/api) f
   departureTime="2022-04-13T01:10:00-07:00"
   departureStation="SEA"
   arrivalTime="2022-04-13T12:30:00-04:00"
-  arrivalStation="EWR">
+  arrivalStation="EWR"
+  stops='[{ "isStopover": true, "arrivalStation": "LAX"}]'>
   <auro-flightline>
     <auro-flight-segment iata="LAX">
   </auro-flightline>

--- a/docs/api.md
+++ b/docs/api.md
@@ -29,6 +29,7 @@ DoT: STATION SIZE AND COLOR MUST BE IDENTICAL TO DISCLOSURE SIZE AND COLOR!
 | `flights`                  | `flights`                  | `Array`  |                                       | Array of flight numbers `['AS 123', 'EK 432']`   |
 | `reroutedArrivalStation`   | `reroutedArrivalStation`   | `String` |                                       | Station of rerouted arrival, e.g. `AVP`          |
 | `reroutedDepartureStation` | `reroutedDepartureStation` | `String` |                                       | Station of rerouted departure, e.g. `PDX`        |
+| `stops`                    | `stops`                    | `Array`  |                                       | Array of objects representing stopovers or layovers: "isStopover": bool, "arrivalStation": string, "duration": string ["123hr 123m"] (layover only). This content will not be used in the UI, but only constructs the a11y conversational phrase for screen readers and has no effect on the `auro-flight-segment` content. |
 | `template`                 |                            | `object` | {}                                    |                                                  |
 | `timeTemplate`             |                            | `object` | {"hour":"2-digit","minute":"2-digit"} | Time template object used by convertTime() method. |
 
@@ -47,17 +48,17 @@ Please DO NOT modify unit tests pertaining to DoT regulations.
 
 ## Properties
 
-| Property                   | Attribute                  | Type      | Default | Description                                      |
-|----------------------------|----------------------------|-----------|---------|--------------------------------------------------|
-| `ariaHidden`               | `ariaHidden`               | `Boolean` | false   | When `true` element will be hidden from screen readers |
-| `arrivalStation`           | `arrivalStation`           | `String`  |         | String for the arrival station. `PVD`            |
-| `arrivalTime`              | `arrivalTime`              | `String`  |         | String for the arrival ISO 8601 time. `2022-04-13T12:30:00-04:00` |
-| `departureStation`         | `departureStation`         | `String`  |         | String for the departure station. `SEA`          |
-| `departureTime`            | `departureTime`            | `String`  |         | String for the departure ISO 8601 time. `2022-04-13T12:30:00-04:00` |
-| `duration`                 | `duration`                 | `Number`  |         | String for the duration. `505`                   |
-| `flights`                  | `flights`                  | `Array`   |         | Array of flight numbers `['AS 123', 'EK 432']`   |
-| `reroutedArrivalStation`   | `reroutedArrivalStation`   | `String`  |         | String for the new arrival station for rerouted flights. `AVP` |
-| `reroutedDepartureStation` | `reroutedDepartureStation` | `String`  |         | String for the new departure station for rerouted flights. `PDX` |
+| Property                   | Attribute                  | Type     | Description                                      |
+|----------------------------|----------------------------|----------|--------------------------------------------------|
+| `arrivalStation`           | `arrivalStation`           | `String` | String for the arrival station. `PVD`            |
+| `arrivalTime`              | `arrivalTime`              | `String` | String for the arrival ISO 8601 time. `2022-04-13T12:30:00-04:00` |
+| `departureStation`         | `departureStation`         | `String` | String for the departure station. `SEA`          |
+| `departureTime`            | `departureTime`            | `String` | String for the departure ISO 8601 time. `2022-04-13T12:30:00-04:00` |
+| `duration`                 | `duration`                 | `Number` | String for the duration. `505`                   |
+| `flights`                  | `flights`                  | `Array`  | Array of flight numbers `['AS 123', 'EK 432']`   |
+| `reroutedArrivalStation`   | `reroutedArrivalStation`   | `String` | String for the new arrival station for rerouted flights. `AVP` |
+| `reroutedDepartureStation` | `reroutedDepartureStation` | `String` | String for the new departure station for rerouted flights. `PDX` |
+| `stops`                    | `stops`                    | `Array`  | Array of objects representing stopovers or layovers: "isStopover": bool, "arrivalStation": string, "duration": string ["123hr 123m"] (layover only) |
 
 ## Slots
 

--- a/docs/partials/demo.md
+++ b/docs/partials/demo.md
@@ -93,7 +93,9 @@ The following example illustrates a change of gauge flight with a layover in SEA
 
 ## Using the footer slot
 
-In this example for a flight that requires government approval or a flight that is operated by another subsidiary or partner carrier, you can use the `footer` custom element slot to insert additional information into the scope of the component. In the code you will see the use of `<auro-icon>` and text within the named slot element.
+In this example for a flight that requires government approval or a flight that is operated by another subsidiary or partner carrier, you can use the `footer` custom element slot to insert additional information into the scope of the component. Notice the use of `<auro-icon>` and text within the named slot element.
+
+This slot requires the consumer to manually manage what is read back via the screen reader through the use of `aria-hidden="true"`.
 
 <div class="exampleWrapper">
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../../apiExamples/footerSlot.html) -->
@@ -149,7 +151,7 @@ Department of Transportation regulations mandate that the arrival and departure 
 
 ## Accessibility
 
-The `<auro-flight>` custom element is accessible by screen readers by default. Due to the style of content within, while this is accessible, it's up to the user of the element if this information is useable and/or necessary for a screen reader experience. If this element is being used for illustrative purposes and the details of the flight are outlined in greater detail outside the scope of this element, it is recommended that the `ariaHidden` attribute be used.
+The `<auro-flight>` custom element is accessible by screen readers by default. Due to the style of content within, while this is accessible, it's up to the user of the element to determine if information is useable and/or necessary for a screen reader experience. If this element is being used for illustrative purposes and the details of the flight are outlined in greater detail outside the scope of this element, `aria-hidden='true'` is recommended.
 
 ## SEO
 

--- a/src/auro-flight-header.js
+++ b/src/auro-flight-header.js
@@ -5,6 +5,7 @@
 
 // If use litElement base class
 import { LitElement, html, css } from "lit-element";
+import { getDateDifference } from "../util/util.js";
 import styleCss from "./style-flight-header-css.js";
 
 // See https://git.io/JJ6SJ for "How to document your components using JSDoc"
@@ -59,23 +60,37 @@ class AuroFlightHeader extends LitElement {
    * @returns {String} Item to display.
    */
   flightDuration() {
-    const departure = this.departureTime.slice(0, -15);
-    const arrival = this.arrivalTime.slice(0, -15);
-    const timeDiff = new Date(arrival).getTime() - new Date(departure).getTime();
-    const dayDiff = timeDiff / (1000 * 3600 * 24);
+    const dayDiff = getDateDifference(this.departureTime, this.arrivalTime);
 
     return dayDiff > 0
       ? html`<span class="daysChanged">+${dayDiff} day${dayDiff > 1 ? 's' : ''}</span>`
       : html``;
   }
 
+  /**
+   * @private
+   * @returns Composed screen reader header.
+   */
+  composeScreenReaderHeader() {
+    return html`
+      ${this.flightType().includes('flights')
+        ? this.flightType()
+        : `Flight ${Array.from(this.flightType()).join(' ')}`
+      },
+      Duration: ${this.duration}
+    `;
+  }
+
   // function that renders the HTML and CSS into  the scope of the component
   render() {
     return html`
-      <span class="flight">
+      <p class="util_displayHiddenVisually">
+        ${this.composeScreenReaderHeader()}  
+      </p>
+      <span class="flight" aria-hidden="true">
         ${this.flightType()}
       </span>
-      <div>
+      <div aria-hidden="true">
         <time class="duration">${this.duration}</time>
         ${this.flightDuration()}
       </div>

--- a/src/auro-flight-main.js
+++ b/src/auro-flight-main.js
@@ -6,20 +6,22 @@
 // If use litElement base class
 import { LitElement, html, css } from "lit-element";
 import styleCss from "./style-flight-main-css.js";
+import { getDateDifference } from './../util/util';
 
 // See https://git.io/JJ6SJ for "How to document your components using JSDoc"
 /**
  * The auro-flight-main element renders the middle 'frame' of the auro-flight component with the auro-flightline.
  * DoT: STATION SIZE AND COLOR MUST BE IDENTICAL TO DISCLOSURE SIZE AND COLOR!
  *
+ * @attr {Array} stops - Array of objects representing stopovers or layovers: "isStopover": bool, "arrivalStation": string, "duration": string ["123hr 123m"] (layover only). This content will not be used in the UI, but only constructs the a11y conversational phrase for screen readers and has no effect on the `auro-flight-segment` content.
+ * @attr {Array} flights - Array of flight numbers `['AS 123', 'EK 432']`
+ * @attr {Number} duration - String for the duration. `505`
  * @attr {String} arrivalTime - ISO 8601 time of arrival, e.g. `2022-04-13T12:30:00-04:00`
  * @attr {String} arrivalStation - Station of arrival, e.g. `SEA`
  * @attr {String} departureTime - ISO 8601 time of departure, e.g. `2022-04-13T12:30:00-04:00`
  * @attr {String} departureStation - Station of departure, e.g. `PVD`
  * @attr {String} reroutedDepartureStation - Station of rerouted departure, e.g. `PDX`
  * @attr {String} reroutedArrivalStation - Station of rerouted arrival, e.g. `AVP`
- * @attr {Array} flights - Array of flight numbers `['AS 123', 'EK 432']`
- * @attr {Number} duration - String for the duration. `505`
  * @slot default - anticipates `<auro-flight-segment>` instances
  */
 
@@ -29,14 +31,15 @@ class AuroFlightMain extends LitElement {
   // function to define props used within the scope of this component
   static get properties() {
     return {
-      arrivalTime:      { type: String },
-      arrivalStation:   { type: String },
-      departureTime:    { type: String },
-      departureStation: { type: String },
+      stops:                    { type: Array },
+      flights:                  { type: Array },
+      duration:                 { type: Number },
+      arrivalTime:              { type: String },
+      arrivalStation:           { type: String },
+      departureTime:            { type: String },
+      departureStation:         { type: String },
+      reroutedArrivalStation:   { type: String },
       reroutedDepartureStation: { type: String },
-      reroutedArrivalStation: { type: String },
-      duration:         { type: Number },
-      flights:          { type: Array }
     };
   }
 
@@ -73,10 +76,66 @@ class AuroFlightMain extends LitElement {
     return localizedTime;
   }
 
+  /**
+   * @private
+   * @param {string} station Airport code ex: SEA.
+   * @returns Mutated string.
+   */
+  readStation(station) {
+    return Array.from(station).join(' ');
+  }
+
+  /**
+   * @param {number} idx A numbered index correlated to current stop.
+   * @private
+   * @returns A comma string or an empty string.
+   */
+  addComma(idx) {
+    return idx === this.stops.length - 1 ? '' : ', ';
+  }
+
+  /**
+   * @private
+   * @returns Composed screen reader summary.
+   */
+  composeScreenReaderSummary() {
+    const hasReroute = this.reroutedDepartureStation && this.reroutedDepartureStation !== 'undefined';
+    const dayDiff = getDateDifference(this.departureTime, this.arrivalTime);
+    const daysFromDeparture = dayDiff === 1 ? 'next day' : `${dayDiff} days later`;
+    const secondToLastIndex = 2;
+    const layoverStopoverStringArray = this.stops
+      ? this.stops.map((segment, idx) => html`
+      with a ${segment.isStopover ? 'stop' : 'layover'} in ${this.readStation(segment.arrivalStation)}
+      ${segment.duration ? `, for ${segment.duration}` : ''}${this.addComma(idx)}
+      ${idx === this.stops.length - secondToLastIndex ? ' and ' : ''}`)
+      : ', nonstop';
+
+    const departureStation = this.readStation(this.departureStation);
+    const departureTime = this.convertTime(this.departureTime);
+    const arrivalStation = this.readStation(this.arrivalStation);
+    const arrivalTime = this.convertTime(this.arrivalTime);
+    let reroutedDepartureStation = '';
+    let reroutedArrivalStation = '';
+
+    if (hasReroute) {
+      reroutedDepartureStation = this.readStation(this.reroutedDepartureStation);
+      reroutedArrivalStation = this.readStation(this.reroutedArrivalStation);
+    }
+
+    return html`
+      ${!hasReroute
+        ? `Departs from ${departureStation} at ${departureTime}, arrives ${arrivalStation} at ${arrivalTime}`
+        : `Flight ${reroutedDepartureStation} to ${reroutedArrivalStation} has been re-routed.
+        The flight now departs from ${departureStation} at ${departureTime},
+        and arrives ${arrivalStation} at ${arrivalTime}`} ${dayDiff > 0 ? `, ${daysFromDeparture}` : ''}
+        ${this.stops ? ', ' : ''} ${layoverStopoverStringArray}.
+    `;
+  }
+
   // function that renders the HTML and CSS into  the scope of the component
   render() {
+    const hasReroute = this.reroutedDepartureStation && this.reroutedDepartureStation !== 'undefined';
     return html`
-
         <script type="application/ld+json">
           {
             "@context": "https://schema.org/",
@@ -90,34 +149,38 @@ class AuroFlightMain extends LitElement {
             "description": "Departs from ${this.departureStation} at ${this.convertTime(this.departureTime)}, arrives ${this.arrivalStation} at ${this.convertTime(this.arrivalTime)}"
           }
         </script>
-
-        <div class="departure">
+        <div class="util_displayHiddenVisually">
+          ${this.composeScreenReaderSummary()}
+        </div>
+        <div class="departure" aria-hidden="true">
           <time class="departureTime">
             <auro-datetime type="tzTime" setDate="${this.departureTime}"></auro-datetime>
           </time>
           <span class="departureStation">
-            ${this.reroutedDepartureStation === "undefined" ? html`` : html`
+          ${hasReroute
+            ? html`
               <span class="util_lineThrough">
                 ${this.reroutedDepartureStation}
-              </span>
-            `}
+              </span>`
+            : html``}
 
             ${this.departureStation}
           </span>
         </div>
-        <div class="slotContainer">
+        <div class="slotContainer" aria-hidden="true">
           <slot></slot>
         </div>
-        <div class="arrival">
+        <div class="arrival" aria-hidden="true">
           <time class="arrivalTime">
             <auro-datetime type="tzTime" setDate="${this.arrivalTime}"></auro-datetime>
           </time>
           <span class="arrivalStation">
-            ${this.reroutedArrivalStation === "undefined" ? html`` : html`
-            <span class="util_lineThrough">
-              ${this.reroutedArrivalStation}
-            </span>
-            `}
+            ${hasReroute
+              ? html`
+                <span class="util_lineThrough">
+                  ${this.reroutedArrivalStation}
+                </span>`
+              : html``}
 
             ${this.arrivalStation}
           </span>

--- a/src/auro-flight.js
+++ b/src/auro-flight.js
@@ -17,6 +17,7 @@ import "./auro-flight-main";
  * This design has been tested via the Alaska Legal team for legal compliance.
  * Please DO NOT modify unit tests pertaining to DoT regulations.
  *
+ * @attr {Array} stops - Array of objects representing stopovers or layovers: "isStopover": bool, "arrivalStation": string, "duration": string ["123hr 123m"] (layover only). This content will not be used in the UI, but only constructs the a11y conversational phrase for screen readers and has no effect on the `auro-flight-segment` content.
  * @attr {Array} flights - Array of flight numbers `['AS 123', 'EK 432']`
  * @attr {Number} duration - String for the duration. `505`
  * @attr {String} departureTime - String for the departure ISO 8601 time. `2022-04-13T12:30:00-04:00`
@@ -25,7 +26,6 @@ import "./auro-flight-main";
  * @attr {String} arrivalStation - String for the arrival station. `PVD`
  * @attr {String} reroutedDepartureStation - String for the new departure station for rerouted flights. `PDX`
  * @attr {String} reroutedArrivalStation - String for the new arrival station for rerouted flights. `AVP`
- * @attr {Boolean} ariaHidden - When `true` element will be hidden from screen readers
  * @slot default - anticipates `<auro-flightline>` instance to fill out the flight timeline
  * @slot departureHeader - Text on top of the departure station's time
  * @slot arrivalHeader - Text on top of the arrival station's time
@@ -34,26 +34,18 @@ import "./auro-flight-main";
 
 // build the component class
 class AuroFlight extends LitElement {
-
-  constructor() {
-    super();
-
-    this.ariaHidden = false;
-  }
-
   // function to define props used within the scope of this component
   static get properties() {
     return {
-      flights:             { type: Array },
-      duration:            { type: Number },
-      departureTime:       { type: String },
-      departureStation:    { type: String },
-      arrivalTime:         { type: String },
-      arrivalStation:      { type: String },
+      stops:                    { type: Array },
+      flights:                  { type: Array },
+      duration:                 { type: Number },
+      departureTime:            { type: String },
+      arrivalTime:              { type: String },
+      arrivalStation:           { type: String },
+      departureStation:         { type: String },
       reroutedArrivalStation:   { type: String },
-      reroutedDepartureStation: { type: String },
-      ariaHidden:          { type: Boolean },
-
+      reroutedDepartureStation: { type: String }
     };
   }
 
@@ -92,8 +84,7 @@ class AuroFlight extends LitElement {
   // function that renders the HTML and CSS into  the scope of the component
   render() {
     return html`
-
-      <section aria-hidden="${this.ariaHidden}">
+      <section>
         <auro-flight-header
           flights=${JSON.stringify(this.flights)}
           duration=${this.convertDuration(this.duration)}
@@ -106,14 +97,15 @@ class AuroFlight extends LitElement {
           <slot name="arrivalHeader"></slot>
         </div>
         <auro-flight-main
+          flights=${JSON.stringify(this.flights)}
+          duration=${this.convertDuration(this.duration)}
           arrivalTime=${this.arrivalTime}
           arrivalStation=${this.arrivalStation}
           departureTime=${this.departureTime}
           departureStation=${this.departureStation}
           reroutedArrivalStation=${this.reroutedArrivalStation}
           reroutedDepartureStation=${this.reroutedDepartureStation}
-          duration=${this.duration}
-          flights=${JSON.stringify(this.flights)}
+          stops=${this.stops ? JSON.stringify(this.stops) : null}
         >
           <slot></slot>
         </auro-flight-main>

--- a/src/style-flight-header.scss
+++ b/src/style-flight-header.scss
@@ -8,6 +8,7 @@
 
 @import './../node_modules/@alaskaairux/webcorestylesheets/dist/breakpoints';
 @import './../node_modules/@alaskaairux/webcorestylesheets/dist/core';
+@import './../node_modules/@alaskaairux/webcorestylesheets/dist/utilityClasses/displayProperties';
 
 // Support for auroElement styles
 // @import './../node_modules/@alaskaairux/orion-web-core-style-sheets/dist/auroElement/auroElement';

--- a/src/style-flight-main.scss
+++ b/src/style-flight-main.scss
@@ -8,6 +8,7 @@
 
 @import './../node_modules/@alaskaairux/webcorestylesheets/dist/breakpoints';
 @import './../node_modules/@alaskaairux/webcorestylesheets/dist/core';
+@import './../node_modules/@alaskaairux/webcorestylesheets/dist/utilityClasses/displayProperties';
 
 // Support for auroElement styles
 // @import './../node_modules/@alaskaairux/orion-web-core-style-sheets/dist/auroElement/auroElement';

--- a/src/style-flight.scss
+++ b/src/style-flight.scss
@@ -8,6 +8,7 @@
 
 @import './../node_modules/@alaskaairux/webcorestylesheets/dist/breakpoints';
 @import './../node_modules/@alaskaairux/webcorestylesheets/dist/core';
+@import './../node_modules/@alaskaairux/webcorestylesheets/dist/utilityClasses/displayProperties';
 
 // Support for auroElement styles
 // @import './node_modules/@alaskaairux/webcorestylesheets/dist/auroElement/auroElement';

--- a/test/auro-flight-header.test.js
+++ b/test/auro-flight-header.test.js
@@ -56,4 +56,23 @@ describe('auro-flight-header', () => {
 
     await expect(el).to.be.true;
   });
+
+  it('auro-flight-header Single Flight screen reader verbiage', async () => {
+    const el = await fixture(html`
+      <auro-flight-header flights='["AS 123"]' duration="180" departureTime="2022-05-04T01:55:00-09:00" arrivalTime="2022-05-04T03:55:00-09:00"></auro-flight-header>
+    `);
+
+    const flightInfoText = el.shadowRoot.querySelector('.util_displayHiddenVisually').textContent.trim().replace(/\n|\r/g, "");
+    
+    await expect(flightInfoText).to.contain('Flight A S   1 2 3,      Duration: 180');
+  });
+
+  it('auro-flight-header Multiple Flights screen reader verbiage', async () => {
+    const el = await fixture(html`
+      <auro-flight-header flights='["AS 123", "EK 432"]' duration="180" departureTime="2022-05-04T01:55:00-09:00" arrivalTime="2022-05-04T03:55:00-09:00"></auro-flight-header>
+    `);
+    const multipleFlightInfoText = el.shadowRoot.querySelector('.util_displayHiddenVisually').textContent.trim().replace(/\n|\r/g, "");
+
+    await expect(multipleFlightInfoText).to.equal('Multiple flights,      Duration: 180');
+  });
 });

--- a/test/auro-flight-main.test.js
+++ b/test/auro-flight-main.test.js
@@ -5,7 +5,7 @@ describe('auro-flight-main', () => {
 
   it('auro-flight-main is accessible', async () => {
     const el = await fixture(html`
-      <auro-flight-main departureTime="2022-05-04T00:30:00-07:00" departureStation="SEA" arrivalTime="2022-05-04T11:55:00-04:00" arrivalStation="PVD" flights='["AS 1436"]'></auro-flight-main>
+      <auro-flight-main departureStation="SEA" departureTime="2022-05-04T00:30:00-07:00" arrivalTime="2022-05-04T11:55:00-04:00" arrivalStation="PVD" flights='["AS 1436"]'></auro-flight-main>
     `);
 
     await expect(el).to.be.accessible();
@@ -13,14 +13,13 @@ describe('auro-flight-main', () => {
 
   it('auro-flight-main fills in information as expected', async () => {
     const el = await fixture(html`
-      <auro-flight-main departureTime="2022-05-04T00:30:00-07:00" departureStation="SEA" arrivalTime="2022-05-04T11:55:00-04:00" arrivalStation="PVD" flights='["AS 1436"]'></auro-flight-main>
+      <auro-flight-main departureTime="2022-05-04T00:30:00-07:00" departureStation="SEA" arrivalTime="2022-05-04T11:55:00-04:00" arrivalStation="PVD" flights='["AS 1436"]' reroutedArrivalStation="SFO" reroutedDepartureStation="LAX"></auro-flight-main>
     `);
 
     await expect(el.shadowRoot.querySelector('.departureTime').querySelector('auro-datetime').getAttribute('setDate')).to.equal('2022-05-04T00:30:00-07:00');
     await expect(el.shadowRoot.querySelector('.arrivalTime').querySelector('auro-datetime').getAttribute('setDate')).to.equal('2022-05-04T11:55:00-04:00');
-    await expect(el.shadowRoot.querySelector('.departureStation').textContent.trim()).to.equal('SEA');
-    await expect(el.shadowRoot.querySelector('.arrivalStation').textContent.trim()).to.equal('PVD');
-
+    await expect(el.shadowRoot.querySelector('.departureStation').textContent.trim()).to.contain('SEA');
+    await expect(el.shadowRoot.querySelector('.arrivalStation').textContent.trim()).to.contain('PVD');
   });
 
   it('auro-flight-main custom element is defined', async () => {
@@ -28,4 +27,166 @@ describe('auro-flight-main', () => {
 
     await expect(el).to.be.true;
   });
+
+  it('auro flight with no reroutes, and a single flight', async () => {
+    const el = await fixture(html`
+      <auro-flight-main 
+        departureTime="2022-05-04T00:30:00-07:00" 
+        departureStation="SEA" 
+        arrivalTime="2022-05-04T11:55:00-04:00"
+        arrivalStation="PVD"
+        flights='["AS 1436"]'>
+      </auro-flight-main>
+    `);
+
+    const expectedDeparture = 'Departs from S E A at 12:30 AM', 
+      expectedArrival = 'arrives P V D at 11:55 AM'; 
+
+    const actual = el.shadowRoot.querySelector('.util_displayHiddenVisually').textContent.trim().replace(/\n|\r/g, "");
+
+    await expect(actual.includes(expectedDeparture)).is.true;
+    await expect(actual.includes(expectedArrival)).is.true;
+  })
+
+  it('non-stop that arrives next day', async () => {
+    const el = await fixture(html`
+      <auro-flight-main 
+        departureTime="2022-05-04T00:30:00-07:00" 
+        departureStation="SEA" 
+        arrivalTime="2022-05-05T11:55:00-04:00"
+        arrivalStation="PVD"
+        flights='["AS 1436"]'>
+      </auro-flight-main>
+    `);
+
+    const expectedComposedDeparture = 'Departs from S E A at 12:30 AM',
+      expectedComposedArrival = 'arrives P V D at 11:55 AM',
+      expectedNextDay = 'next day',
+      expectedNonstop = 'nonstop';
+
+    const actual = el.shadowRoot.querySelector('.util_displayHiddenVisually').textContent.trim().replace(/\n|\r/g, "");
+    
+    await expect(actual.includes(expectedComposedDeparture)).is.true;
+    await expect(actual.includes(expectedComposedArrival)).is.true;
+    await expect(actual.includes(expectedNextDay)).is.true;
+    await expect(actual.includes(expectedNonstop)).is.true;
+  })
+
+  it('non-stop that arrives two days later', async () => {
+    const el = await fixture(html`
+      <auro-flight-main
+        departureTime="2022-05-04T00:30:00-07:00" 
+        departureStation="SEA" 
+        arrivalTime="2022-05-06T11:55:00-04:00"
+        arrivalStation="PVD"
+        flights='["AS 1436"]'>
+      </auro-flight-main>
+    `);
+    const expectedDeparture = 'Departs from S E A at 12:30 AM',
+      expectedArrival = 'arrives P V D at 11:55 AM',
+      expectedComposition = '2 days later';
+
+    const actual = el.shadowRoot.querySelector('.util_displayHiddenVisually').textContent.trim().replace(/\n|\r/g, "");
+
+    await expect(actual.includes(expectedDeparture)).is.true;
+    await expect(actual.includes(expectedArrival)).is.true;
+    await expect(actual.includes(expectedComposition)).is.true;
+  })
+
+  it('auro flight with reroutes', async () => {
+    const el = await fixture(html`
+      <auro-flight-main 
+        departureTime="2022-05-04T00:30:00-07:00" 
+        departureStation="SEA" 
+        arrivalTime="2022-05-04T11:55:00-04:00"
+        arrivalStation="PVD"
+        flights='["AS 1436"]'
+        reroutedArrivalStation="SFO" 
+        reroutedDepartureStation="LAX">
+      </auro-flight-main>
+    `);
+    
+    const expectedDeparture = 'The flight now departs from S E A at 12:30 AM',
+    expectedArrival = 'and arrives P V D at 11:55 AM',
+    expectedReroutedFlight = 'Flight L A X to S F O has been re-routed';
+    
+    const actual = el.shadowRoot.querySelector('.util_displayHiddenVisually').textContent.trim().replace(/\n|\r/g, "");
+    
+    await expect(actual.includes(expectedReroutedFlight)).is.true;
+    await expect(actual.includes(expectedDeparture)).is.true;
+    await expect(actual.includes(expectedArrival)).is.true;
+  })
+
+  it('flight with a stopover', async () => {
+    const el = await fixture(html`
+      <auro-flight-main 
+        departureTime="2022-05-04T00:30:00-07:00" 
+        departureStation="SEA" 
+        arrivalTime="2022-05-04T11:55:00-04:00"
+        arrivalStation="PVD"
+        flights='["AS 1436"]'
+        stops='[{ "arrivalStation": "LAX", "isStopover": true }]'>
+      </auro-flight-main>
+    `);
+
+    const composedDeparture = 'Departs from S E A at 12:30 AM',
+      composedArrival = 'arrives P V D at 11:55 AM',
+      composedStop = 'with a stop in L A X';
+
+    const actual = el.shadowRoot.querySelector('.util_displayHiddenVisually').textContent.trim().replace(/\n|\r/g, "");
+
+    await expect(actual.includes(composedDeparture)).is.true;
+    await expect(actual.includes(composedArrival)).is.true;
+    await expect(actual.includes(composedStop)).is.true;
+  })
+
+  it('flight with a layover', async () => {
+    const el = await fixture(html`
+      <auro-flight-main 
+        departureTime="2022-05-04T00:30:00-07:00" 
+        departureStation="SEA" 
+        arrivalTime="2022-05-04T11:55:00-04:00"
+        arrivalStation="PVD"
+        flights='["AS 1436"]'
+        stops='[{ "arrivalStation": "SFO", "duration": "1hr 42m", "isStopover": false }]'>
+      </auro-flight-main>
+    `);
+    const composedDeparture = 'Departs from S E A at 12:30 AM,',
+      composedArrival = 'arrives P V D at 11:55 AM',
+      composedLayover = 'with a layover in S F O',
+      composedDuration = 'for 1hr 42m';
+
+    const actual = el.shadowRoot.querySelector('.util_displayHiddenVisually').textContent.trim().replace(/\n|\r/g, "");
+
+    await expect(actual.includes(composedDeparture)).is.true;
+    await expect(actual.includes(composedArrival)).is.true;
+    await expect(actual.includes(composedLayover)).is.true;
+    await expect(actual.includes(composedDuration)).is.true;
+  })
+
+  it('flight with a layover', async () => {
+    const el = await fixture(html`
+      <auro-flight-main 
+        departureTime="2022-05-04T00:30:00-07:00" 
+        departureStation="SEA" 
+        arrivalTime="2022-05-04T11:55:00-04:00"
+        arrivalStation="PVD"
+        flights='["AS 1436"]'
+        stops='[{ "arrivalStation": "LAX", "isStopover": true }, { "arrivalStation": "SFO", "duration": "1hr 42m", "isStopover": false }]'>
+      </auro-flight-main>
+    `);
+    const composedDeparture = 'Departs from S E A at 12:30 AM, arrives P V D at 11:55 AM',
+      composedStop = 'with a stop in L A X',
+      composedConnectorText = 'and',
+      composedLayover = 'with a layover in S F O',
+      composedDuration = 'for 1hr 42m';
+
+    const actual = el.shadowRoot.querySelector('.util_displayHiddenVisually').textContent.trim().replace(/\n|\r/g, "");
+
+    await expect(actual.includes(composedDeparture)).is.true;
+    await expect(actual.includes(composedStop)).is.true;
+    await expect(actual.includes(composedConnectorText)).is.true;
+    await expect(actual.includes(composedLayover)).is.true;
+    await expect(actual.includes(composedDuration)).is.true;
+  })
 });

--- a/util/util.js
+++ b/util/util.js
@@ -1,0 +1,6 @@
+export function getDateDifference(departureTime, arrivalTime){
+  const departure = departureTime.slice(0, -15);
+  const arrival = arrivalTime.slice(0, -15);
+  const timeDiff = new Date(arrival).getTime() - new Date(departure).getTime();
+  return timeDiff / (1000 * 3600 * 24);
+}


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

The component was updated to be accessibility compliant by allowing screen readers to read the flight duration, flight arrival time, flight departure time, flight arrival station, and flight departure station in a full sentence. Layover, stopover, and nonstop flights are explicitly stated as well. If a flight arrives the next day the screen reader will also indicate this.

Fixes: #25 

## Summary:

_Please summarize the scope of the changes you have submitted, what the intent of the work is and anything that describes the before/after state of the project._

## Type of change:
* Updated the auro-flight component to take in the stops/layover information
* Updated the auro-header to no longer state if a flight is nonstop
* Updated the auro-flight-main component to

Please delete options that are not relevant.

- [x] New capability
- [ ] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
