### PR TITLE
feat: extract `flight-main`'s css parts

### DIFF
--- a/apiExamples/customizeFont.html
+++ b/apiExamples/customizeFont.html
@@ -1,0 +1,26 @@
+<auro-flight
+  id="customizeFont"
+  flights='["AS 1436"]'
+  duration="161"
+  departureTime="2022-07-13T12:15:00-07:00"
+  departureStation="SEA"
+  arrivalTime="2022-07-13T14:56:00-07:00"
+  arrivalStation="LAX">
+  <auro-flightline></auro-flightline>
+</auro-flight>
+
+<style>
+  #customizeFont::part(arrivalTime) {
+    font-size: 2rem;
+    font-weight: bolder;
+  }
+  #customizeFont::part(departureTime) {
+    font-size: 1.8rem;
+  }
+  #customizeFont::part(arrivalStation) {
+    color: red;
+  }
+  #customizeFont::part(departureStation) {
+    color: blue;
+  }
+</style>

--- a/demo/api.md
+++ b/demo/api.md
@@ -77,6 +77,12 @@ DoT: STATION SIZE AND COLOR MUST BE IDENTICAL TO DISCLOSURE SIZE AND COLOR!
 | [template](#template)                 |                            | `object` | {}                                    |                                                  |
 | [timeTemplate](#timeTemplate)             |                            | `object` | {"hour":"2-digit","minute":"2-digit"} | Time template object used by convertTime() method. |
 
+## Methods
+
+| Method           | Type       | Description                                      |
+|------------------|------------|--------------------------------------------------|
+| [exposeCssParts](#exposeCssParts) | `(): void` | Exposes CSS parts for styling from parent components. |
+
 ## Slots
 
 | Name      | Description                                   |
@@ -88,7 +94,11 @@ DoT: STATION SIZE AND COLOR MUST BE IDENTICAL TO DISCLOSURE SIZE AND COLOR!
 | Part                 | Description                                      |
 |----------------------|--------------------------------------------------|
 | [arrivalContainer](#arrivalContainer)   | Apply css to the elements within the arrival container |
+| [arrivalStation](#arrivalStation)     | Apply css to the elements to the arrival station |
+| [arrivalTime](#arrivalTime)        | Apply css to the elements to the arrival time    |
 | [departureContainer](#departureContainer) | Apply css to the elements within the departure container |
+| [departureStation](#departureStation)   | Apply css to the elements to the departure station |
+| [departureTime](#departureTime)      | Apply css to the elements to the departure time  |
 <!-- AURO-GENERATED-CONTENT:END -->
 
 ## API Examples
@@ -314,6 +324,75 @@ Explanation and use description.
   arrivalStation="LAX">
   <auro-flightline></auro-flightline>
 </auro-flight>
+```
+<!-- AURO-GENERATED-CONTENT:END -->
+</auro-accordion>
+
+### CSS Shadow Parts Example
+
+Use css part of `arrivalTime`, `arrivalStation`, `departureTime`, `departureStation` to customize their fonts
+
+<div class="exampleWrapper">
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/customizeFont.html) -->
+  <!-- The below content is automatically added from ./../apiExamples/customizeFont.html -->
+  <auro-flight
+    id="customizeFont"
+    flights='["AS 1436"]'
+    duration="161"
+    departureTime="2022-07-13T12:15:00-07:00"
+    departureStation="SEA"
+    arrivalTime="2022-07-13T14:56:00-07:00"
+    arrivalStation="LAX">
+    <auro-flightline></auro-flightline>
+  </auro-flight>
+  <style>
+    #customizeFont::part(arrivalTime) {
+      font-size: 2rem;
+      font-weight: bolder;
+    }
+    #customizeFont::part(departureTime) {
+      font-size: 1.8rem;
+    }
+    #customizeFont::part(arrivalStation) {
+      color: red;
+    }
+    #customizeFont::part(departureStation) {
+      color: blue;
+    }
+  </style>
+  <!-- AURO-GENERATED-CONTENT:END -->
+</div>
+<auro-accordion alignRight>
+  <span slot="trigger">See code</span>
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/customizeFont.html) -->
+<!-- The below code snippet is automatically added from ./../apiExamples/customizeFont.html -->
+
+```html
+<auro-flight
+  id="customizeFont"
+  flights='["AS 1436"]'
+  duration="161"
+  departureTime="2022-07-13T12:15:00-07:00"
+  departureStation="SEA"
+  arrivalTime="2022-07-13T14:56:00-07:00"
+  arrivalStation="LAX">
+  <auro-flightline></auro-flightline>
+</auro-flight>
+<style>
+  #customizeFont::part(arrivalTime) {
+    font-size: 2rem;
+    font-weight: bolder;
+  }
+  #customizeFont::part(departureTime) {
+    font-size: 1.8rem;
+  }
+  #customizeFont::part(arrivalStation) {
+    color: red;
+  }
+  #customizeFont::part(departureStation) {
+    color: blue;
+  }
+</style>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
 </auro-accordion>

--- a/docs/api.md
+++ b/docs/api.md
@@ -76,6 +76,12 @@ DoT: STATION SIZE AND COLOR MUST BE IDENTICAL TO DISCLOSURE SIZE AND COLOR!
 | `template`                 |                            | `object` | {}                                    |                                                  |
 | `timeTemplate`             |                            | `object` | {"hour":"2-digit","minute":"2-digit"} | Time template object used by convertTime() method. |
 
+## Methods
+
+| Method           | Type       | Description                                      |
+|------------------|------------|--------------------------------------------------|
+| `exposeCssParts` | `(): void` | Exposes CSS parts for styling from parent components. |
+
 ## Slots
 
 | Name      | Description                                   |
@@ -87,4 +93,8 @@ DoT: STATION SIZE AND COLOR MUST BE IDENTICAL TO DISCLOSURE SIZE AND COLOR!
 | Part                 | Description                                      |
 |----------------------|--------------------------------------------------|
 | `arrivalContainer`   | Apply css to the elements within the arrival container |
+| `arrivalStation`     | Apply css to the elements to the arrival station |
+| `arrivalTime`        | Apply css to the elements to the arrival time    |
 | `departureContainer` | Apply css to the elements within the departure container |
+| `departureStation`   | Apply css to the elements to the departure station |
+| `departureTime`      | Apply css to the elements to the departure time  |

--- a/docs/partials/api.md
+++ b/docs/partials/api.md
@@ -108,6 +108,22 @@ Explanation and use description.
 </auro-accordion>
 
 
+### CSS Shadow Parts Example
+
+Use css part of `arrivalTime`, `arrivalStation`, `departureTime`, `departureStation` to customize their fonts
+
+<div class="exampleWrapper">
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/customizeFont.html) -->
+  <!-- AURO-GENERATED-CONTENT:END -->
+</div>
+<auro-accordion alignRight>
+  <span slot="trigger">See code</span>
+
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/customizeFont.html) -->
+<!-- AURO-GENERATED-CONTENT:END -->
+
+</auro-accordion>
+
 ### Theme Support
 
 The component may be restyled using the following code sample and changing the values of the following token(s).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aurodesignsystem/auro-flight",
-  "version": "3.2.2",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-flight",
-      "version": "3.2.2",
+      "version": "4.0.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/auro-flight-main.js
+++ b/src/auro-flight-main.js
@@ -37,6 +37,10 @@ import { getDateDifference } from '../util/util.js';
  * @slot default - anticipates `<auro-flight-segment>` instances
  * @csspart arrivalContainer - Apply css to the elements within the arrival container
  * @csspart departureContainer - Apply css to the elements within the departure container
+ * @csspart arrivalTime - Apply css to the elements to the arrival time
+ * @csspart departureTime - Apply css to the elements to the departure time
+ * @csspart arrivalStation - Apply css to the elements to the arrival station
+ * @csspart departureStation - Apply css to the elements to the departure station
  */
 
 // build the component class
@@ -84,6 +88,14 @@ export class AuroFlightMain extends LitElement {
      * @private
      */
     this.datetimeTag = versioning.generateTag('auro-datetime', datetimeVersion, AuroDatetime);
+  }
+
+  /**
+   * Exposes CSS parts for styling from parent components.
+   * @returns {void}
+   */
+  exposeCssParts() {
+    this.setAttribute('exportparts', 'departureTime:departureTime, arrivalTime:arrivalTime, departureStation:departureStation, arrivalStation:arrivalStation');
   }
 
   /**
@@ -170,10 +182,10 @@ export class AuroFlightMain extends LitElement {
           ${this.composeScreenReaderSummary()}
         </div>
         <div class="departure" aria-hidden="true" part="departureContainer">
-          <time class="departureTime">
+          <time class="departureTime" part="departureTime">
             <${this.datetimeTag} type="tzTime" setDate="${this.departureTime}"></${this.datetimeTag}>
           </time>
-          <span class="departureStation">
+          <span class="departureStation" part="departureStation">
           ${hasDepartureReroute
             ? html`
               <span>
@@ -189,10 +201,10 @@ export class AuroFlightMain extends LitElement {
           <slot></slot>
         </div>
         <div class="arrival" aria-hidden="true" part="arrivalContainer">
-          <time class="arrivalTime">
+          <time class="arrivalTime" part="arrivalTime">
             <${this.datetimeTag} type="tzTime" setDate="${this.arrivalTime}"></${this.datetimeTag}>
           </time>
-          <span class="arrivalStation">
+          <span class="arrivalStation" part="arrivalStation">
             ${hasArrivalReroute
               ? html`
                 <span>

--- a/src/auro-flight.js
+++ b/src/auro-flight.js
@@ -97,10 +97,12 @@ export class AuroFlight extends LitElement {
     const slot = this.shadowRoot.querySelector("#footer"),
       slotWrapper = this.shadowRoot.querySelector("#flightFooter");
 
+    const main = this.shadowRoot.querySelector("auro-flight-main");
+    main.exposeCssParts();
+
     if (!this.unformatted && slot.assignedNodes().length === 0) {
       return slotWrapper.classList.remove("flightFooter");
     }
-
     return null;
   }
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

Adding time and station's parts for departure and arrival so that each of their font can be customized

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Expose CSS parts for styling the departure and arrival times and stations in the auro-flight-main component. This allows users to customize the fonts of these elements.

Enhancements:
- Expose CSS parts for styling departure and arrival times and stations.
- Add a method to expose CSS parts for styling from parent components.
- Update documentation to include the new CSS parts and a usage example.